### PR TITLE
fix: allow invoking base injector when using cjs

### DIFF
--- a/src/core/injector/base_injector.ts
+++ b/src/core/injector/base_injector.ts
@@ -33,6 +33,9 @@ export abstract class BaseInjector implements Injector {
     self?: SELF | null,
     ...rest: REST
   ): Promise<RET> {
+    
+    fn = fn.default || fn;
+      
     if (isInjectedFunction(fn)) {
       try {
         const selfType = fn.$thisType;


### PR DESCRIPTION
When the user's app is built using CommonJS, Qwik cannot invoke the base injector function because it's exported as `default`. This change fixed the issue.